### PR TITLE
history and notifications

### DIFF
--- a/flutter_app/lib/presentation/history/history_screen.dart
+++ b/flutter_app/lib/presentation/history/history_screen.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import '../widgets/top_bar.dart';
+import '../widgets/debug_nav.dart';
+import '../../theme/app_theme.dart';
+
+class HistoryScreen extends StatelessWidget {
+  const HistoryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final List<Map<String, String>> history = [
+      {
+        "title": "Claim Request was verified",
+        "date": "12/09/2025 at 1:43 PM",
+        "detail": "Umbrella found by Martin",
+      },
+      {
+        "title": "Claim Request sent",
+        "date": "10/09/2025 at 5:43 PM",
+        "detail": "Umbrella found by Martin\nlink to post",
+      },
+      {
+        "title": "Found Object posted",
+        "date": "23/07/2025 at 5:43 PM",
+        "detail": "Water bottle found\nlink to post",
+      },
+    ];
+
+    return Scaffold(
+      appBar: const TopBar(
+        title: 'History',
+        actions: [DebugNavButton()], // 👈 aquí también
+      ),
+      body: ListView.separated(
+        padding: const EdgeInsets.all(16),
+        itemBuilder: (context, i) {
+          final h = history[i];
+          return Container(
+            padding: const EdgeInsets.all(14),
+            decoration: BoxDecoration(
+              color: AppTheme.pill,
+              borderRadius: BorderRadius.circular(16),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withOpacity(0.08),
+                  blurRadius: 6,
+                  offset: const Offset(0, 3),
+                ),
+              ],
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  h["title"] ?? "",
+                  style: const TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 15,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  h["date"] ?? "",
+                  style: const TextStyle(fontSize: 12),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  h["detail"] ?? "",
+                  style: const TextStyle(fontSize: 13),
+                ),
+              ],
+            ),
+          );
+        },
+        separatorBuilder: (_, __) => const SizedBox(height: 12),
+        itemCount: history.length,
+      ),
+      backgroundColor: AppTheme.tealBg,
+    );
+  }
+}

--- a/flutter_app/lib/presentation/notifications/notifications_screen.dart
+++ b/flutter_app/lib/presentation/notifications/notifications_screen.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import '../widgets/top_bar.dart';
+import '../widgets/debug_nav.dart';
+import '../../theme/app_theme.dart';
+
+class NotificationsScreen extends StatelessWidget {
+  const NotificationsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final List<Map<String, dynamic>> notifications = [
+      {"msg": "You have a new email!", "highlight": true},
+      {"msg": "Post successfully created", "highlight": false},
+      {"msg": "Object claimed!", "highlight": false},
+      {"msg": "You have a new email!", "highlight": false},
+    ];
+
+    return Scaffold(
+      appBar: const TopBar(
+        title: 'Notifications',
+        actions: [DebugNavButton()], // 👈 aquí añadimos el menú
+      ),
+      body: ListView.separated(
+        padding: const EdgeInsets.all(16),
+        itemBuilder: (context, i) {
+          final n = notifications[i];
+          return Container(
+            padding: const EdgeInsets.all(14),
+            decoration: BoxDecoration(
+              color: n["highlight"] == true ? AppTheme.orange : Colors.white,
+              borderRadius: BorderRadius.circular(16),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withOpacity(0.08),
+                  blurRadius: 6,
+                  offset: const Offset(0, 3),
+                ),
+              ],
+            ),
+            child: Text(
+              n["msg"] as String,
+              style: const TextStyle(
+                fontWeight: FontWeight.w600,
+                fontSize: 16,
+              ),
+            ),
+          );
+        },
+        separatorBuilder: (_, __) => const SizedBox(height: 12),
+        itemCount: notifications.length,
+      ),
+      backgroundColor: AppTheme.tealBg,
+    );
+  }
+}

--- a/flutter_app/lib/presentation/widgets/debug_nav.dart
+++ b/flutter_app/lib/presentation/widgets/debug_nav.dart
@@ -10,10 +10,12 @@ class DebugNavButton extends StatelessWidget {
       icon: const Icon(Icons.bug_report),
       onSelected: (route) => Navigator.pushNamed(context, route),
       itemBuilder: (context) => const [
-        PopupMenuItem(value: AppRoutes.profile, child: Text('Go Profile')),
-        PopupMenuItem(value: AppRoutes.lostReport, child: Text('Go Lost Report')),
-        PopupMenuItem(value: AppRoutes.claim, child: Text('Go Claim')),
-        PopupMenuItem(value: AppRoutes.matchDetail, child: Text('Go Match Detail')),
+        PopupMenuItem(value: AppRoutes.profile,      child: Text('Go Profile')),
+        PopupMenuItem(value: AppRoutes.lostReport,   child: Text('Go Lost Report')),
+        PopupMenuItem(value: AppRoutes.claim,        child: Text('Go Claim')),
+        PopupMenuItem(value: AppRoutes.matchDetail,  child: Text('Go Match Detail')),
+        PopupMenuItem(value: AppRoutes.notifications,child: Text('Go Notifications')),
+        PopupMenuItem(value: AppRoutes.history,      child: Text('Go History')),
       ],
     );
   }

--- a/flutter_app/lib/routes/app_routes.dart
+++ b/flutter_app/lib/routes/app_routes.dart
@@ -9,7 +9,8 @@ import '../presentation/profile/profile_screen.dart';
 import '../presentation/lost_report/lost_report_screen.dart';
 import '../presentation/claim/claim_object_screen.dart';
 import '../presentation/match_detail/item_description_screen.dart';
-
+import '../presentation/notifications/notifications_screen.dart';
+import '../presentation/history/history_screen.dart';
 class AppRoutes {
   static const String login = '/login';
   static const String register = '/register';
@@ -20,6 +21,8 @@ class AppRoutes {
   static const String foundReport = '/found_report';
   static const String claim = '/claim';
   static const String matchDetail = '/match_detail';
+  static const String notifications = '/notifications';
+  static const String history = '/history';
 
   static Map<String, WidgetBuilder> get routes {
     return {
@@ -31,6 +34,9 @@ class AppRoutes {
       lostReport: (_) => const LostReportScreen(),
       claim: (_) => const ClaimObjectScreen(),
       matchDetail: (_) => const ItemDescriptionScreen(),
+          notifications: (_) => const NotificationsScreen(),
+          history: (_) => const HistoryScreen()
+
     };
   }
 }


### PR DESCRIPTION
I did two new screens, notifications and history. The Notifications screen displays recent alerts like new emails, posts, and claims, while the History screen shows a timeline of user actions such as verified claims and found item reports. Both screens include the TopBar with the debug navigation menu for consistent navigation across the app.